### PR TITLE
Arregla el problema del tamaño de ProducCard en relación al input

### DIFF
--- a/src/pages/styles/HomePage.css
+++ b/src/pages/styles/HomePage.css
@@ -27,6 +27,7 @@
     border-color: black solid;
 }
 .product-container {
+    
     display: flex;
     justify-content: center;
     gap: 1.5em 2em;
@@ -45,8 +46,7 @@
         display: flex;
         justify-content: center;
         gap: 1.5em 2em;
-        flex-wrap: wrap;
-        
+        flex-wrap: wrap; 
     }
     .div__input-home {
         width: 100%;
@@ -79,9 +79,10 @@
     }
     .product-container {
         max-width: 16em;
+        min-width: 15.8em;
         display: flex;
         justify-content: center;
-        gap: 1.5em 2em;
+        
         flex-wrap: wrap;
     }
     
@@ -89,7 +90,7 @@
 
 @media (max-width: 380px) {
     .product-container {
-        max-width: 14em;
+       
         
     }
 }


### PR DESCRIPTION
Agrega un atributo "min-with: 15.5em;" a HomePage.css en media query de max740px. Así se resolvió el problema de que la card se hacía angosta al ingresar una búsqueda en el input.